### PR TITLE
Check NonCons type in car and cdr dispatch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ python:
   - "3.8"
   - "pypy3"
 
+env:
+  global:
+    - COVERALLS_PARALLEL=true
+
 install:
   - pip install -r requirements.txt
 
@@ -19,3 +23,6 @@ script:
 
 after_success:
   - coveralls
+
+notifications:
+  webhooks: https://coveralls.io/webhook

--- a/cons/core.py
+++ b/cons/core.py
@@ -66,7 +66,7 @@ class ConsNull(metaclass=ConsNullType):
 
     @abstractmethod
     def __init__(self):
-        pass
+        raise NotImplementedError()
 
 
 class ConsPair(metaclass=ConsType):
@@ -177,7 +177,7 @@ class MaybeCons(metaclass=MaybeConsType):
 
     @abstractmethod
     def __init__(self):
-        pass
+        raise NotImplementedError()
 
 
 class NonCons(ABC):
@@ -189,7 +189,7 @@ class NonCons(ABC):
 
     @abstractmethod
     def __init__(self):
-        pass
+        raise NotImplementedError()
 
 
 for t in (type(None), str, set, UserString, ByteString):
@@ -238,6 +238,11 @@ def _car_OrderedDict(z):
     return first(z.items())
 
 
+@_car.register(NonCons)
+def _car_NonCons(z):
+    raise ConsError(f"{z} is a NonCons type")
+
+
 def cdr(z):
     if issubclass(type(z), ConsPair):
         return z.cdr
@@ -267,3 +272,8 @@ def _cdr_OrderedDict(z):
     if len(z) == 0:
         raise ConsError("Not a cons pair")
     return cdr(list(z.items()))
+
+
+@_cdr.register(NonCons)
+def _cdr_NonCons(z):
+    raise ConsError(f"{z} is a NonCons type")

--- a/tests/test_cons.py
+++ b/tests/test_cons.py
@@ -124,6 +124,9 @@ def test_cons_str():
 def test_car_cdr():
 
     with pytest.raises(ConsError):
+        car(object())
+
+    with pytest.raises(ConsError):
         car(None)
 
     with pytest.raises(ConsError):
@@ -134,6 +137,12 @@ def test_car_cdr():
 
     with pytest.raises(ConsError):
         car(iter([]))
+
+    with pytest.raises(ConsError):
+        car("ab")
+
+    with pytest.raises(ConsError):
+        cdr(object())
 
     with pytest.raises(ConsError):
         cdr(None)
@@ -152,6 +161,9 @@ def test_car_cdr():
 
     with pytest.raises(ConsError):
         cdr(OrderedDict())
+
+    with pytest.raises(ConsError):
+        cdr("ab")
 
     assert car([1, 2]) == 1
     assert cdr([1, 2]) == [2]


### PR DESCRIPTION
This missing check was resulting in `car("ab") == "a"` even though `isinstance("a", NonCons)`.