### PR TITLE
Remove unnecessary rest function

### DIFF
--- a/cons/core.py
+++ b/cons/core.py
@@ -13,15 +13,6 @@ from toolz import last, first
 # from toolz.itertoolz import rest
 
 
-def rest(seq):
-    if isinstance(seq, Sequence):
-        return seq[1:]
-    elif isinstance(seq, Iterator) and length_hint(seq, 2) <= 1:
-        return iter([])
-
-    return islice(seq, 1, None)
-
-
 class ConsError(ValueError):
     pass
 
@@ -259,14 +250,18 @@ def cdr(z):
 def _cdr(z):
     if len(z) == 0:
         raise ConsError("Not a cons pair")
-    return type(z)(rest(z))
+    return z[1:]
 
 
 @_cdr.register(Iterator)
 def _cdr_Iterator(z):
     if length_hint(z, 1) == 0:
         raise ConsError("Not a cons pair")
-    return rest(z)
+
+    if isinstance(z, Iterator) and length_hint(z, 2) <= 1:
+        return iter([])
+
+    return islice(z, 1, None)
 
 
 @_cdr.register(OrderedDict)

--- a/tests/test_cons.py
+++ b/tests/test_cons.py
@@ -8,7 +8,7 @@ from collections.abc import Iterator
 from unification import unify, reify, var
 
 from cons import cons, car, cdr
-from cons.core import ConsPair, MaybeCons, ConsNull, rest, ConsError, NonCons
+from cons.core import ConsPair, MaybeCons, ConsNull, ConsError, NonCons
 
 
 def assert_all_equal(*tests):
@@ -54,7 +54,6 @@ def test_cons_type():
     assert not isinstance("hi", ConsPair)
     assert not isinstance(1, ConsPair)
     assert not isinstance(iter([]), ConsPair)
-    assert not isinstance(rest(iter([1])), ConsPair)
     assert not isinstance(OrderedDict({}), ConsPair)
     assert not isinstance((), ConsPair)
     assert not isinstance([], ConsPair)
@@ -70,7 +69,6 @@ def test_cons_null():
     assert isinstance(tuple(), ConsNull)
     assert isinstance(OrderedDict(), ConsNull)
     assert isinstance(iter([]), ConsNull)
-    assert isinstance(rest(iter([1])), ConsNull)
     assert not isinstance(object, ConsNull)
     assert not isinstance([1], ConsNull)
     assert not isinstance((1,), ConsNull)
@@ -212,11 +210,14 @@ def test_car_cdr():
     # We need to make sure that `__getitem__` is actually used.
     from collections import UserList
 
+    # Also, make sure `cdr` returns the `__getitem__` result unaltered
+    clist_res = [5]
+
     class CustomList(UserList):
         def __getitem__(self, *args):
-            return [5]
+            return clist_res
 
-    assert cdr(CustomList([1, 2, 3])) == [5]
+    assert cdr(CustomList([1, 2, 3])) is clist_res
 
 
 def test_unification():


### PR DESCRIPTION
After the last PR, it was clear that `rest` is unnecessary and wasteful (e.g. multiple, repeated type checks).  Also, `cdr` was unnecessarily cloning the results of `__getitem__`.