### PR TITLE
Make cons use custom __(r)add__ methods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name="cons",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-    install_requires=["toolz", "logical-unification"],
+    install_requires=["logical-unification"],
     packages=find_packages(exclude=["tests"]),
     tests_require=["pytest"],
     author="Brandon T. Willard",

--- a/tests/test_cons.py
+++ b/tests/test_cons.py
@@ -2,7 +2,7 @@ import pytest
 
 from functools import reduce
 from itertools import chain, cycle
-from collections import OrderedDict
+from collections import OrderedDict, UserList
 from collections.abc import Iterator
 
 from unification import unify, reify, var
@@ -113,6 +113,16 @@ def test_cons_join():
     assert cons("a", cons("b", "c")).car == "a"
     assert cons("a", cons("b", "c")).cdr == cons("b", "c")
 
+    # Make sure that an overridden "append" (via `__add__`) is used and
+    # that the results are returned unadulterated
+    clist_res = [1, 2, 3]
+
+    class CustomList(UserList):
+        def __add__(self, a):
+            return clist_res
+
+    assert cons(1, CustomList([2, 3])) is clist_res
+
 
 def test_cons_str():
     assert repr(cons(1, 2)) == "ConsPair(1, 2)"
@@ -208,8 +218,6 @@ def test_car_cdr():
     assert cdr(cons(1, cons("a", "b"))) == cons("a", "b")
 
     # We need to make sure that `__getitem__` is actually used.
-    from collections import UserList
-
     # Also, make sure `cdr` returns the `__getitem__` result unaltered
     clist_res = [5]
 


### PR DESCRIPTION
This is another update that makes `cons` honor more custom/build-in class methods and further reduces unnecessary object cloning.  Also, this PR also removes the `toolz` dependency.