### PR TITLE
Use a valid SPDX identifier as license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "cons"
 dynamic = ["version"]
 description = "An implementation of Lisp/Scheme-like cons in Python."
 readme = "README.md"
+license: "LGPL-3.0"
 license-files = ["LICENSE.txt"]
 authors = [
     { name = "Brandon T. Willard", email = "brandonwillard+cons@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "cons"
 dynamic = ["version"]
 description = "An implementation of Lisp/Scheme-like cons in Python."
 readme = "README.md"
-license: "LGPL-3.0"
+license = "LGPL-3.0"
 license-files = ["LICENSE.txt"]
 authors = [
     { name = "Brandon T. Willard", email = "brandonwillard+cons@gmail.com" },


### PR DESCRIPTION
This helps automatic license checkers like pip-licenses to identify the right license for this project