### PR TITLE
Use a valid SPDX identifier as license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "cons"
 dynamic = ["version"]
 description = "An implementation of Lisp/Scheme-like cons in Python."
 readme = "README.md"
+license = "LGPL-3.0-only"
 license-files = ["LICENSE.txt"]
 authors = [
     { name = "Brandon T. Willard", email = "brandonwillard+cons@gmail.com" },


### PR DESCRIPTION
Fixes license specifiers according to https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

This allows automatic license inspection tools like pip-licenses to correctly categorize this package.